### PR TITLE
Change references to "master" branch to "main"

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -3,7 +3,7 @@ name: Lint Docs
 on:
   push:
     branches:
-    - master
+    - main
     paths:
     - "*.md"
     - "**/*.md"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint Ruby
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
 
 jobs:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-[no unreleased changes yet]
+
+- Rename primary branch from `master` to `main`
 
 ## v5.0.0 (2023-12-29)
 

--- a/runger_config.gemspec
+++ b/runger_config.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri' => 'http://github.com/davidrunger/runger_config/issues',
-    'changelog_uri' => 'https://github.com/davidrunger/runger_config/blob/master/CHANGELOG.md',
+    'changelog_uri' => 'https://github.com/davidrunger/runger_config/blob/main/CHANGELOG.md',
     'documentation_uri' => 'http://github.com/davidrunger/runger_config',
     'funding_uri' => 'https://github.com/sponsors/davidrunger',
     'homepage_uri' => 'http://github.com/davidrunger/runger_config',


### PR DESCRIPTION
I have renamed the "master" branch in GitHub to "main", so we need to update these references to reflect that change.