### PR TITLE
Bump actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -16,7 +16,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.3
@@ -27,7 +27,7 @@ jobs:
   lychee:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Link Checker
       id: lychee
       uses: lycheeverse/lychee-action@v1.5.1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -23,7 +23,7 @@ jobs:
           gemfile: "Gemfile"
           rbs: 'true'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
This fixes a deprecation warning about "Node.js 16 actions are deprecated".