### PR TITLE
Update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,8 +81,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ammeter (1.1.7)
       activesupport (>= 3.0)
       railties (>= 3.0)
@@ -135,9 +135,9 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.23.1)
+    minitest (5.24.0)
     mutex_m (0.2.0)
-    net-imap (0.4.13)
+    net-imap (0.4.14)
       date
       net-protocol
     net-pop (0.1.2)
@@ -162,9 +162,9 @@ GEM
       pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
-    public_suffix (5.1.0)
+    public_suffix (6.0.0)
     racc (1.8.0)
-    rack (3.1.3)
+    rack (3.1.4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -213,7 +213,7 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
-    rexml (3.3.0)
+    rexml (3.3.1)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -227,7 +227,7 @@ GEM
     rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-rails (6.1.2)
+    rspec-rails (6.1.3)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
       date
       net-protocol
     net-pop (0.1.2)
+      net-protocol
     net-protocol (0.2.2)
       timeout
     net-smtp (0.5.0)


### PR DESCRIPTION
`bundle update`

Also, add `net-protocol` as a dependency of `net-pop` in `Gemfile.lock`.

```
gem uninstall net-pop
gem install net-pop
bundle update net-pop
```

Many thanks to https://stackoverflow.com/a/78620570/4009384 for the solution!

Bug: https://github.com/ruby/net-pop/issues/ 26

Fix: https://github.com/ruby/ruby/pull/ 11006

Failing build [here](https://github.com/davidrunger/runger_config/actions/runs/9672982937/job/26686194697?pr=20).

```
Downloading net-pop-0.1.2 revealed dependencies not in the API or the lockfile
(net-protocol (>= 0)).
Running `bundle update net-pop` should fix the problem.
Error: The process '/opt/hostedtoolcache/Ruby/3.3.3/x64/bin/bundle' failed with exit code 34
```