### PR TITLE
Move dev/test dependencies from gemspec to Gemfile [CONF-2]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ ruby file: '.ruby-version'
 source 'https://rubygems.org'
 
 group :development, :test do
+  gem 'ammeter'
+  gem 'ejson'
+  gem 'rake'
   gem 'rubocop'
   gem 'rubocop-md'
   gem 'rubocop-performance'
@@ -15,6 +18,11 @@ end
 group :development do
   gem 'pry-byebug'
   gem 'runger_release_assistant', require: false
+end
+
+group :test do
+  gem 'rspec'
+  gem 'webmock'
 end
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,13 +306,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ammeter (~> 1.1.3)
-  ejson (>= 1.3.1)
+  ammeter
+  ejson
   pry-byebug
   rails (~> 7.0)
-  rake (>= 13.0)
+  rake
   rbs (~> 3.0)!
-  rspec (>= 3.8)
+  rspec
   rubocop
   rubocop-md
   rubocop-performance
@@ -321,7 +321,7 @@ DEPENDENCIES
   runger_release_assistant
   runger_style
   steep (~> 1.4)!
-  webmock (~> 3.18)
+  webmock
 
 RUBY VERSION
    ruby 3.3.4p94

--- a/runger_config.gemspec
+++ b/runger_config.gemspec
@@ -36,10 +36,4 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= #{required_ruby_version}"
 
   spec.add_runtime_dependency('activesupport', '>= 7.1.2')
-
-  spec.add_development_dependency('ammeter', '~> 1.1.3')
-  spec.add_development_dependency('ejson', '>= 1.3.1')
-  spec.add_development_dependency('rake', '>= 13.0')
-  spec.add_development_dependency('rspec', '>= 3.8')
-  spec.add_development_dependency('webmock', '~> 3.18')
 end


### PR DESCRIPTION
As discussed e.g. here https://github.com/rubygems/rubygems/issues/ 7799 , the suggested place to put development dependencies is in a Gemfile rather than in the gemspec.