### PR TITLE
[gemspec] Work around dependabot bug by using 'File.public_send'

### DIFF
--- a/runger_config.gemspec
+++ b/runger_config.gemspec
@@ -32,7 +32,13 @@ Gem::Specification.new do |spec|
     Dir.glob('bin/**/*') + %w[sig/runger_config.rbs sig/manifest.yml] +
     %w[README.md LICENSE.txt CHANGELOG.md]
   spec.require_paths = ['lib']
-  required_ruby_version = File.read('.ruby-version').rstrip.sub(/\A(\d+\.\d+)\.\d+\z/, '\1.0')
+
+  # HACK: Using public_send rather than read works around a Dependabot bug.
+  # rubocop:disable Style/SendWithLiteralMethodName
+  required_ruby_version =
+    File.public_send(:read, '.ruby-version').
+      rstrip.sub(/\A(\d+\.\d+)\.\d+\z/, '\1.0')
+  # rubocop:enable Style/SendWithLiteralMethodName
   spec.required_ruby_version = ">= #{required_ruby_version}"
 
   spec.add_dependency('activesupport', '>= 7.1.2')


### PR DESCRIPTION
... rather than `File.read` to read the Ruby version from the `.ruby-version` file.

The issue is that Dependabot overwrites all `File.read` content in the gemspec with the gem's own version number (I guess on the assumption that `File.read` might be used to read the value of `spec.version`, i.e. the gem's own version number, from a version file). I think that basically happens here: https://github.com/dependabot/dependabot-core/blob/42d95a29/bundler/lib/dependabot/bundler/file_updater/gemspec_sanitizer.rb/#L369-L371