### PR TITLE
[dependabot] Specify a max of 20 open Dependabot PRs (vs default 5)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
       timezone: America/Chicago
     allow:
       - dependency-type: all
+    open-pull-requests-limit: 20


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-

Motivation: I think we are way behind. Let's increase the max so that we can catch up more quickly. And, in the future, I don't want to max out at 5. We could go even higher than 20, but I think that's the limit I have in other repos, and I think there is some value in being consistent (e.g. for easier bulk find-and-replace later).