### PR TITLE
Bump rbs from 3.7.0 to 3.8.1 and steep from 1.9.1 to 1.9.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.7.0)
+    rbs (3.8.1)
       logger
     rdoc (6.11.0)
       psych (>= 4.0.0)
@@ -268,7 +268,7 @@ GEM
       rubocop (>= 1.68.0)
     securerandom (0.4.1)
     slop (4.10.1)
-    steep (1.9.1)
+    steep (1.9.4)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
@@ -279,10 +279,11 @@ GEM
       logger (>= 1.3.0)
       parser (>= 3.1)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 3.7.0)
+      rbs (~> 3.8)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 4)
+      uri (>= 0.12.0)
     stringio (3.1.2)
     strscan (3.1.2)
     terminal-table (3.0.2)
@@ -403,7 +404,7 @@ CHECKSUMS
   rake (13.2.1) sha256=46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
-  rbs (3.7.0) sha256=97870668ffa420585932c88b43799e622d188a6425f1f433410e400f630e2cea
+  rbs (3.8.1) sha256=2b6ce37952e267e1d3ad330aabfadbdceac234193a60cc18f25a8f75fa949c1d
   rdoc (6.11.0) sha256=bec66fb9b019be64f7ba7d2cd2aecb283a3a01fef23a95b33e2349c6d1aa0040
   regexp_parser (2.10.0) sha256=cb6f0ddde88772cd64bff1dbbf68df66d376043fe2e66a9ef77fcb1b0c548c61
   reline (0.6.0) sha256=57620375dcbe56ec09bac7192bfb7460c716bbf0054dc94345ecaa5438e539d2
@@ -425,7 +426,7 @@ CHECKSUMS
   runger_style (4.3.0) sha256=543c2414626d9084fef8fd057bf561c702e395f35e7af4ee6ee403276cf60614
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   slop (4.10.1) sha256=844322b5ffcf17ed4815fdb173b04a20dd82b4fd93e3744c88c8fafea696d9c7
-  steep (1.9.1) sha256=6ae9423608db49d7c3385e3a4059dba52c061fe3f8db571a1acb7fb8badcf21f
+  steep (1.9.4) sha256=09a941469b55d31cdc70a3812b5c1d4102d361f628f5fe5497b6a9aabc3cee05
   stringio (3.1.2) sha256=204f1828f85cdb39d57cac4abc6dc44b04505a223f131587f2e20ae3729ba131
   strscan (3.1.2) sha256=5529ff36c95fe752b8489f2e6c7f4f230fd9904e0b24fdc6e0833436c63ee2e3
   terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91


### PR DESCRIPTION
For some reason, Dependabot is erroring when trying to update these. https://github.com/davidrunger/runger_config/actions/runs/13155983382/job/36713122858