### PR TITLE
Remove matrix from GitHub Actions

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.4
+        bundler-cache: true
     - name: Run Markdown linter
       run: |
         gem install mdl

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.4
         bundler-cache: true
     - name: Lint Ruby code with RuboCop
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -15,22 +15,14 @@ jobs:
     env:
       BUNDLE_JOBS: 4
       BUNDLE_RETRY: 3
-      BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
       VERIFY_RESERVED: 1
       CI: true
     strategy:
       fail-fast: false
-      matrix:
-        include:
-        - ruby: "3.4"
-          gemfile: "Gemfile"
-          rbs: 'true'
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler: 2.2.15
         bundler-cache: true
     - name: Run RSpec
       run: |
@@ -45,7 +37,6 @@ jobs:
       run: |
         bundle exec rake spec:autoload
     - name: Run RSpec with RBS runtime checks
-      if: matrix.rbs == 'true'
       env:
         # RBS adds method aliases
         VERIFY_RESERVED: 0


### PR DESCRIPTION
Also, remove `ruby-version` references from `ruby/setup-ruby` steps.

This will result, I think, in using the version that is in the `.ruby-version` file, which is what I want.